### PR TITLE
Fixed dropped div in the merge of dakota feature pq 10

### DIFF
--- a/client/containers/Wrapper.jsx
+++ b/client/containers/Wrapper.jsx
@@ -55,6 +55,7 @@ const Wrapper = props => {
         </div>
         <div className="col">
           <RightNav ticketsCount={props.ticketsCount}/>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
### **Problem**
Accidentally dropped closing </div> in wrapper.jsx when merging [pq 10](https://github.com/team-snapdesk/snapdesk/pull/10) into master.

### **Solution**
Added dropped div back in and the app works.